### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'pnpm'
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Install Node dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Type check
+        run: pnpm check
+      - name: Build frontend
+        run: pnpm build
+      - name: Build Rust backend
+        run: cargo build --manifest-path src-tauri/Cargo.toml --release


### PR DESCRIPTION
## Summary
- add basic GitHub Actions workflow for Node and Rust

## Testing
- `pnpm check` *(fails: svelte-kit not found)*
- `cargo build --manifest-path src-tauri/Cargo.toml --release` *(fails: Could not connect to server)*
