### PR TITLE
Fix layout width

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -259,7 +259,8 @@
 
   .history-section,
   .saved-section {
-    flex: 1;
+    flex: 1 1 50%;
+    max-width: 50%;
   }
 
   .saved-container {


### PR DESCRIPTION
## Summary
- restrict history and saved section width to 50%

## Testing
- `pnpm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c3f0d2ee483249a2cea845ea5ba8a